### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [unit-tests]
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/stix26/Megatron-LM/security/code-scanning/9](https://github.com/stix26/Megatron-LM/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the `Performance Tests` job. This block will explicitly define the minimal permissions required for the job. Based on the job's steps, it does not appear to require write access to the repository or other sensitive permissions. Therefore, we will set `contents: read` as the minimal starting point. This ensures the job can read repository contents if needed while preventing unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
